### PR TITLE
Remove no-Domain requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ When the browser navigates to another top-level site, then subsequent requests t
 
 #### `Secure` and `Path` attributes
 
-User agenst must reject any cookie set with `Partitioned` that does not also include the `Secure` and `Path=/`.
+User agent must reject any cookie set with `Partitioned` that does not also include the `Secure` and `Path=/`.
 
 #### `HttpOnly` attribute
 

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ This algorithm could be added to [section 5.3 of RFC6265bis](https://datatracker
 1.  Append an attribute to the cookie-attribute-list with an attribute-name of "PartitionKey" and an attribute-value of "partition-key".
 
 Below is the algorithm for storing `Partitioned` cookies.
-These steps could be added to [section 5.4 of RFC6265bis](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-07#section-5.4).
+These steps could be added to [section 5.4 of RFC6265bis](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-07#section-5.4) after after the user agent checks for the `__Host-` prefix.
 
 1.  If the cookie-attribute-list contains an attribute with an attribute-name of "PartitionKey" and the attribute-value is null, then skip the following steps and insert the cookie into the cookie store.
 

--- a/README.md
+++ b/README.md
@@ -329,11 +329,11 @@ This algorithm could be added to [section 5.3 of RFC6265bis](https://datatracker
 1.  Append an attribute to the cookie-attribute-list with an attribute-name of "PartitionKey" and an attribute-value of "partition-key".
 
 Below is the algorithm for storing `Partitioned` cookies.
-These steps could be added to [section 5.4 of RFC6265bis](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-07#section-5.4) after the user agent processes the cookie's __Host- prefix.
+These steps could be added to [section 5.4 of RFC6265bis](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-07#section-5.4).
 
 1.  If the cookie-attribute-list contains an attribute with an attribute-name of "PartitionKey" and the attribute-value is null, then skip the following steps and insert the cookie into the cookie store.
 
-1. If the cookie line does not contain the `Secure` and `Path=/` then ignore the following steps and ignore the cookie entirely.
+1. 1. If the cookie-attribute-list does not contain an attribute with an attribute-name of `Secure` and an attribute with an attribute-name of `Path` and attribute-value of `/` then abort these steps and ignore the cookie entirely.
 
 1.  If the cookie line also contains the [`SameParty` attribute](https://github.com/cfredric/sameparty) (the exact semantics of how the `SameParty` attribute is loaded into the cookie-attribute-list is TBD) then abort the following steps and ignore the cookie entirely.
 


### PR DESCRIPTION
After discussing [#43](https://github.com/privacycg/CHIPS/issues/43) in the call today, we decided that the no-Domain requirement will be removed from CHIPS to help ease the adoption of partitioned cookies and the removal of unpartitioned third-party cookies.