### PR TITLE
Remove Path=/ requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For more information about the design of the Origin-Trial, see the [documentatio
         - [Third-party customer support widgets](#third-party-customer-support-widgets)
         - [CDN load balancing](#cdn-load-balancing)
     - [How to enforce design principles](#how-to-enforce-design-principles)
-        - [`Secure` and `Path` attributes](#secure-and-path-attributes)
+        - [`Secure` attribute](#secure-attributes)
         - [`HttpOnly` attribute](#httponly-attribute)
         - [`SameSite` attribute](#samesite-attribute)
         - [`SameParty` attribute](#sameparty-attribute)
@@ -333,7 +333,7 @@ These steps could be added to [section 5.4 of RFC6265bis](https://datatracker.ie
 
 1.  If the cookie-attribute-list contains an attribute with an attribute-name of "PartitionKey" and the attribute-value is null, then skip the following steps and insert the cookie into the cookie store.
 
-1. 1. If the cookie-attribute-list does not contain an attribute with an attribute-name of `Secure` and an attribute with an attribute-name of `Path` and attribute-value of `/` then abort these steps and ignore the cookie entirely.
+1. 1. If the cookie-attribute-list does not contain an attribute with an attribute-name of `Secure` then abort these steps and ignore the cookie entirely.
 
 1.  If the cookie line also contains the [`SameParty` attribute](https://github.com/cfredric/sameparty) (the exact semantics of how the `SameParty` attribute is loaded into the cookie-attribute-list is TBD) then abort the following steps and ignore the cookie entirely.
 
@@ -421,9 +421,9 @@ When the browser navigates to another top-level site, then subsequent requests t
 
 ### How to enforce design principles
 
-#### `Secure` and `Path` attributes
+#### `Secure` attribute
 
-User agent must reject any cookie set with `Partitioned` that does not also include the `Secure` and `Path=/`.
+User agent must reject any cookie set with `Partitioned` that does not also include the `Secure`.
 
 #### `HttpOnly` attribute
 

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ These steps could be added to [section 5.4 of RFC6265bis](https://datatracker.ie
 
 1.  If the cookie-attribute-list contains an attribute with an attribute-name of "PartitionKey" and the attribute-value is null, then skip the following steps and insert the cookie into the cookie store.
 
-1. 1. If the cookie-attribute-list does not contain an attribute with an attribute-name of `Secure` then abort these steps and ignore the cookie entirely.
+1. If the cookie-attribute-list does not contain an attribute with an attribute-name of `Secure` then abort these steps and ignore the cookie entirely.
 
 1.  If the cookie line also contains the [`SameParty` attribute](https://github.com/cfredric/sameparty) (the exact semantics of how the `SameParty` attribute is loaded into the cookie-attribute-list is TBD) then abort the following steps and ignore the cookie entirely.
 


### PR DESCRIPTION
Based on the discussion in [#47](https://github.com/privacycg/CHIPS/issues/47) there seems to be consensus that the `Path=/` requirement is not needed. This PR removes the requirement from the explainer, but does not remove the use of `Path=/` in `Set-Cookie` examples.